### PR TITLE
fix: Update Jekyll baseurl for custom domain

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ title: FerrisDB
 description: >-
   Educational distributed database in Rust - Learning LSM-trees, MVCC, 
   and distributed systems with Claude Code. Inspired by FoundationDB.
-baseurl: "/ferrisdb"
+baseurl: "/"
 url: "https://ferrisdb.nullcoder.net"
 github_username: nullcoder
 repository: nullcoder/ferrisdb


### PR DESCRIPTION
## Summary
Fix Jekyll baseurl configuration to properly support the custom domain `ferrisdb.nullcoder.net`.

## Changes
- **baseurl**: Changed from `"/ferrisdb"` to `"/"` 
- **Reason**: Custom domains don't need subdirectory paths in baseurl

## Problem Solved
The previous configuration `baseurl: "/ferrisdb"` was causing issues with:
- Internal navigation links pointing to wrong URLs
- Asset loading (CSS, images) failing 
- Relative URL generation being incorrect

## Expected Result
With `baseurl: "/"`, all Jekyll-generated URLs will work correctly on the custom domain:
- Navigation links: `https://ferrisdb.nullcoder.net/getting-started/` ✅
- Assets: `https://ferrisdb.nullcoder.net/assets/css/style.css` ✅  
- Blog posts: `https://ferrisdb.nullcoder.net/blog/day-1-building-ferrisdb-foundations/` ✅

## Testing
The change is minimal and standard for Jekyll sites using custom domains. GitHub Pages will automatically rebuild the site with the corrected configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)