### PR TITLE
fix: Update README.md with current project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ A distributed, transactional key-value database written in Rust, inspired by Fou
 
 ### Prerequisites
 
-- Rust 1.75 or higher
-- RocksDB development libraries
+- Rust 1.81 or higher
+- Git
 
 ### Installation
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/ferrisdb.git
+git clone https://github.com/nullcoder/ferrisdb.git
 cd ferrisdb
 
 # Build the project
@@ -128,7 +128,10 @@ FerrisDB is designed for high performance:
 ## Roadmap
 
 - [x] Design document
-- [ ] Core storage engine
+- [x] Write-Ahead Log (WAL)
+- [x] MemTable with SkipList
+- [ ] SSTable implementation (in progress)
+- [ ] Compaction system
 - [ ] Transaction system
 - [ ] Distribution layer
 - [ ] Consensus protocol
@@ -137,7 +140,7 @@ FerrisDB is designed for high performance:
 
 ## License
 
-FerrisDB is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+FerrisDB is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for details.
 
 ## Acknowledgments
 
@@ -148,11 +151,12 @@ This project is inspired by [FoundationDB](https://apple.github.io/foundationdb/
 - CockroachDB
 - TiKV
 
-## Community
+## Documentation
 
-- [Discord Server](#) (Coming soon)
-- [Documentation](#) (Coming soon)
-- [Benchmarks](#) (Coming soon)
+- [Architecture Overview](docs/architecture.md)
+- [Getting Started Guide](docs/getting-started.md)
+- [WAL and Crash Recovery Deep Dive](docs/wal-crash-recovery.md)
+- [LSM-Trees Deep Dive](docs/lsm-trees-deep-dive.md)
 
 ## Status
 


### PR DESCRIPTION
## Summary
- Update README.md to reflect current project state and fix outdated information
- Remove references to RocksDB dependency (now using custom LSM-tree implementation)
- Update documentation links and project metadata

## Changes
- ✅ Updated Rust version requirement from 1.75 to 1.81
- ✅ Removed RocksDB from prerequisites (replaced with Git)
- ✅ Fixed GitHub repository URL from placeholder to `nullcoder/ferrisdb`
- ✅ Corrected license information from MIT to Apache License 2.0
- ✅ Updated roadmap to show completed items:
  - Write-Ahead Log (WAL) - completed
  - MemTable with SkipList - completed
  - SSTable implementation - in progress
  - Compaction system - pending
- ✅ Replaced placeholder community section with actual documentation links:
  - Architecture Overview
  - Getting Started Guide
  - WAL and Crash Recovery Deep Dive
  - LSM-Trees Deep Dive

## Test Plan
- [x] Verify all links in README.md are valid
- [x] Confirm Rust version matches project requirements
- [x] Check license file matches README declaration
- [x] Ensure documentation links point to existing files

🤖 Generated with [Claude Code](https://claude.ai/code)