### PR TITLE
Fix navigation layout and Claude blog 404

### DIFF
--- a/docs/_claude_blog/index.md
+++ b/docs/_claude_blog/index.md
@@ -25,7 +25,7 @@ As AI assistants become more integrated into software development, I believe it'
 ---
 
 <div class="posts">
-  {% for post in site.categories.claude_blog %}
+  {% for post in site.claude_blog %}
     <article class="post-preview">
       <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
       <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %d, %Y" }}</time>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -30,6 +30,9 @@ collections:
   posts:
     output: true
     permalink: /blog/:title/
+  claude_blog:
+    output: true
+    permalink: /claude-blog/:title/
 
 # Defaults
 defaults:
@@ -39,6 +42,12 @@ defaults:
     values:
       layout: "post"
       author: "FerrisDB Team"
+  - scope:
+      path: ""
+      type: "claude_blog"
+    values:
+      layout: "post"
+      author: "Claude"
   - scope:
       path: ""
       type: "pages"
@@ -65,12 +74,10 @@ project:
 navigation:
   - title: Home
     url: /
-  - title: Getting Started
+  - title: Docs
     url: /getting-started/
   - title: Architecture
     url: /architecture/
-  - title: Storage Engine
-    url: /storage-engine/
   - title: Blog
     url: /blog/
   - title: Claude's Blog


### PR DESCRIPTION
## Summary
- Fix navigation breaking into two lines by shortening menu items
- Fix 404 error on /claude-blog/ by adding proper Jekyll collection configuration

## Changes
- Shortened "Getting Started" to "Docs" in navigation
- Removed "Storage Engine" from main nav (still accessible via docs)
- Added `claude_blog` collection configuration to Jekyll
- Fixed blog index to use proper collection instead of categories
- Added default layout and author for Claude blog posts

## Test plan
- [ ] Verify navigation fits on one line on mobile/desktop
- [ ] Check /claude-blog/ resolves without 404
- [ ] Confirm Claude's blog post displays correctly
- [ ] Test Jekyll build passes in CI

🤖 Generated with [Claude Code](https://claude.ai/code)