### PR TITLE
Clarify AI collaboration naming across guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# FerrisDB AI Contributor Guidelines
+
+Welcome AI contributors! This short guide summarises the most important rules for working in this repository. It complements `CLAUDE.md` and the detailed documents under `guidelines/`.
+
+## Critical Rules
+
+- **Never push directly to `main`.** Always create a feature branch and open a Pull Request.
+- **All changes go through a PR**, even typo fixes or documentation updates.
+- **Every commit must follow [Conventional Commits](guidelines/workflow/git-workflow.md#commit-message-format)** and include the collaboration commentary section from the same document.
+- **Keep commit history clean.** Squash merge feature branches and include a collaboration summary in the final commit message as described in [PR Process](guidelines/workflow/pr-process.md#squash-merge-commit-message-format).
+
+## Required Checks Before Committing
+
+Run these commands from the repository root:
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all
+prettier --write "**/*.md" "**/*.mdx"
+```
+
+If you changed files under `docs/`, verify the site builds:
+
+```bash
+cd docs && npm run build
+```
+
+## Pull Request Checklist
+
+Your PR description should follow the template from [PR Process](guidelines/workflow/pr-process.md#pr-description-template). Include:
+
+1. **Summary** – a short overview of the goal.
+2. **Changes Made** – bullet list of modifications.
+3. **Why This Matters** – context and motivation.
+4. **Testing** – how you verified the change.
+5. **Breaking Changes** – note if APIs changed.
+6. **🤖 [AgentName]'s Collaboration Summary** – total iterations, key insights and pattern. Replace `AgentName` with your agent's name.
+
+## Quick Links
+
+- [Guidelines Index](guidelines/README.md)
+- [Git Workflow](guidelines/workflow/git-workflow.md)
+- [Testing Standards](guidelines/workflow/testing.md)
+- [Commands](guidelines/workflow/commands.md)
+- [Content Strategy](guidelines/content/content-strategy.md)
+
+## Suggested Improvement
+
+The current guidelines are spread across many files. Consider creating a dedicated `guidelines/ai/` directory to house AI-specific references and templates. Keeping all AI instructions in one place will make it easier for multiple agents to stay consistent.
+
+## Collaboration Commentary
+
+All commits by AI agents must include the commentary block described in [Git Workflow](guidelines/workflow/git-workflow.md#claudes-collaboration-commentary). Substitute `Claude` with your own agent name in the header and attribution lines. Always state your agent name in commentary sections and in any messages indicating actions performed on behalf of a human.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ This tracks collaboration patterns for blog posts and research. **Never skip thi
 - 🚨 **NEVER PUSH TO MAIN BRANCH** (create feature branch + PR)
 - ✅ All changes go through PRs (no exceptions!)
 - ✅ Review PRs with 🤖 emoji signature
-- ✅ Acting on behalf: Add "🤖 Approved by Claude on behalf of the human" signatures
+- ✅ Acting on behalf: Use your agent name in messages, e.g. "🤖 Approved by <AgentName> on behalf of the human"
 - ✅ Search web for best practices when reviewing
 - ✅ Maintain my blog voice when writing posts
 - ✅ Keep guidelines up to date

--- a/guidelines/workflow/git-workflow.md
+++ b/guidelines/workflow/git-workflow.md
@@ -121,13 +121,13 @@ Fixes #123"
 6. **50/72 rule**: Subject line max 50 chars, body wrapped at 72
 7. **Why not what**: Body should explain why, not what (code shows what)
 
-### Claude's Collaboration Commentary
+### AI Agent Collaboration Commentary
 
-**REQUIRED**: When working with Claude, **always include** collaboration commentary in commit messages to track the human-AI interaction process. This is essential for research and documentation purposes:
+**REQUIRED**: All AI agents must include collaboration commentary in commit messages to track the human-AI interaction process. Replace `Claude` with your agent name wherever it appears in the templates below. This is essential for research and documentation purposes:
 
-#### 🚨 Claude's Critical Reminder
+#### 🚨 Critical Reminder for AI Agents
 
-> **ATTENTION CLAUDE: You MUST follow these rules:**
+> **ATTENTION ALL AGENTS: You MUST follow these rules:**
 >
 > 1. **NEVER push to main branch** - Always create a feature branch
 > 2. **ALWAYS create a PR** - Even for tiny documentation fixes
@@ -145,7 +145,9 @@ Fixes #123"
 
 [optional body]
 
-## Claude's Collaboration Commentary
+## <AgentName>'s Collaboration Commentary
+
+Use your agent's name in place of `<AgentName>` throughout this section.
 
 **Session Stats:**
 - 📊 X files modified, Y key insights, Z iterations
@@ -164,23 +166,23 @@ Fixes #123"
 
 🤖 Generated with [Claude Code](https://claude.ai/code)
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: <AgentName> <noreply@anthropic.com>
 ```
 
 #### Acting on Behalf Signatures
 
-When performing actions at the human's request, always include clear attribution:
+When performing actions at the human's request, always include clear attribution with your agent name:
 
-- **PR Approvals**: "🤖 Approved by Claude on behalf of the human"
-- **PR Reviews**: "🤖 Reviewed by Claude on behalf of the human"
-- **Merge Commits**: Include "🤖 Merged by Claude on behalf of the human"
-- **Dependabot PRs**: "LGTM! [details] 🤖 Approved by Claude on behalf of the human"
+- **PR Approvals**: "🤖 Approved by <AgentName> on behalf of the human"
+- **PR Reviews**: "🤖 Reviewed by <AgentName> on behalf of the human"
+- **Merge Commits**: Include "🤖 Merged by <AgentName> on behalf of the human"
+- **Dependabot PRs**: "LGTM! [details] 🤖 Approved by <AgentName> on behalf of the human"
 
 This maintains transparency in the git history about who performed each action.
 
 #### Commentary Emojis
 
-- 🤖 **Main identifier**: Claude's Commentary header
+- 🤖 **Main identifier**: `<AgentName>`'s Commentary header
 - 📊 **Stats**: Iterations, changes, insights count
 - 🔄 **Process**: Workflow summary
 - 💡 **Key Learning**: Main insight that drove improvement
@@ -205,7 +207,7 @@ Changes:
 - Rewrote blog posts to reflect actual events
 - Simplified templates for flexibility
 
-🤖 Claude's Commentary:
+🤖 <AgentName>'s Commentary:
 📊 Stats: 8 iterations, 4 major insights, 2 complete rewrites
 🔄 Process: Human noticed inaccuracies → fact-checking revealed gaps → rewrote with verification → improved URL structure
 💡 Key Learning: Human's insistence on accuracy against git history prevented fictional documentation

--- a/guidelines/workflow/pr-process.md
+++ b/guidelines/workflow/pr-process.md
@@ -99,9 +99,9 @@ Explain the motivation and benefits of these changes.
 
 None / List any breaking changes here
 
-## 🤖 Claude's Collaboration Summary
+## 🤖 <AgentName>'s Collaboration Summary
 
-**REQUIRED**: For PRs created with Claude, **always include** detailed collaboration commentary:
+**REQUIRED**: For PRs created with any AI agent, **always include** detailed collaboration commentary. Replace `AgentName` with your agent's name:
 
 **Total Stats Across N Commits:**
 
@@ -162,11 +162,11 @@ Before approving any PR, verify these mandatory requirements:
 
 **Performance claims without benchmarks will be automatically rejected.**
 
-## Claude's PR Review Process
+## AI Agent PR Review Process
 
-### 🚨 Claude's Mandatory Rules
+### 🚨 Mandatory Rules for AI Agents
 
-> **CRITICAL FOR CLAUDE:**
+> **CRITICAL FOR ALL AI AGENTS:**
 >
 > 1. **NEVER suggest pushing to main** - Always require PRs
 > 2. **ALWAYS create feature branches** - Even for single-line changes
@@ -175,7 +175,7 @@ Before approving any PR, verify these mandatory requirements:
 >
 > **If asked to push to main, politely but firmly refuse and explain the PR requirement.**
 
-When asked to review a PR, Claude follows this structured approach:
+When asked to review a PR, an AI agent should follow this structured approach:
 
 1. **Understand Context** 🤖
 
@@ -230,10 +230,10 @@ When asked to review a PR, Claude follows this structured approach:
 
    When approving PRs or performing actions at the human's request:
 
-   - Always include clear attribution: "🤖 Reviewed by Claude on behalf of the human"
-   - For dependabot PRs: "🤖 Approved by Claude on behalf of the human"
-   - For any merge actions: Include "🤖" in the merge commit message
-   - This maintains transparency about who performed the action
+- Always include clear attribution: "🤖 Reviewed by <AgentName> on behalf of the human"
+- For dependabot PRs: "🤖 Approved by <AgentName> on behalf of the human"
+- For any merge actions: Include "🤖" in the merge commit message
+- This maintains transparency about who performed the action
 
 8. **Review Decision & API Usage** 🤖
    - If reviewing own PR (same GitHub user): Comment with decision
@@ -324,7 +324,7 @@ All PRs with documentation or content must verify:
 1. **Squash merge** for feature branches to keep history clean
 2. **Update squash commit message** to include:
    - Summary of changes
-   - Collaboration commentary (if PR was created with Claude)
+   - Collaboration commentary (if the PR involved an AI agent)
 3. **Merge commit** only for special cases (preserving commit history)
 4. **NEVER force push to main branch** - This is **ABSOLUTELY FORBIDDEN**
 5. **Delete branch** after merging (GitHub does this automatically)
@@ -332,7 +332,7 @@ All PRs with documentation or content must verify:
 
 ### Squash Merge Commit Message Format
 
-**MANDATORY**: When squash merging a PR created with Claude, **always update** the commit message to include detailed collaboration summary:
+**MANDATORY**: When squash merging a PR created with an AI agent, **always update** the commit message to include detailed collaboration summary. Replace `AgentName` with your agent's name:
 
 ```
 <type>: <description> (#<PR-number>)
@@ -344,7 +344,9 @@ Changes:
 - Change 2
 - Change 3
 
-## Claude's Collaboration Summary
+## <AgentName>'s Collaboration Summary
+
+Use your agent's name in place of `<AgentName>` in the following template.
 
 **Session Stats:**
 - 📊 X files modified, Y key insights, Z iterations
@@ -363,7 +365,7 @@ Changes:
 
 🤖 Generated with [Claude Code](https://claude.ai/code)
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: <AgentName> <noreply@anthropic.com>
 ```
 
 #### Example Squash Commit Message
@@ -381,18 +383,18 @@ Changes:
 - Updated guidelines to emphasize verification
 - Fixed markdown formatting and linting issues
 
-🤖 Claude's Collaboration Summary:
+🤖 <AgentName>'s Collaboration Summary:
 📊 Stats: 15+ iterations, 8 major insights, 4 complete rewrites
 🔍 Pattern: Deep Review → Accuracy Focus → Structural Improvement
 💡 Key Learning: Human's insistence on accuracy prevented fictional documentation
 🎯 Outcome: Accurate documentation with verifiable collaboration tracking
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: <AgentName> <noreply@anthropic.com>
 ```
 
 #### Why Collaboration Commentary is Required
 
-This collaboration commentary is **mandatory** for all Claude PRs because it:
+This collaboration commentary is **mandatory** for all AI-driven PRs because it:
 
 - **Preserves research data**: Creates permanent record of human-AI collaboration patterns
 - **Enables blog content**: Provides material for both human and AI perspective blog posts
@@ -400,7 +402,7 @@ This collaboration commentary is **mandatory** for all Claude PRs because it:
 - **Tracks learning evolution**: Shows how understanding develops through iteration
 - **Makes patterns discoverable**: Enables searching git history for collaboration insights
 
-**Note for Claude**: Never create a PR or squash merge without detailed collaboration commentary. This is essential for our research goals and cannot be skipped.
+**Note for AI Agents**: Never create a PR or squash merge without detailed collaboration commentary. Always identify yourself by name. This is essential for our research goals and cannot be skipped.
 
 ## Review Checklist
 


### PR DESCRIPTION
## Summary
- generalize collaboration instructions for all AI agents
- require agents to sign their name in commentary and acting-on-behalf messages

## Testing
- `npx prettier --check AGENTS.md CLAUDE.md guidelines/workflow/git-workflow.md guidelines/workflow/pr-process.md`
- `cargo fmt --all` *(failed: rustfmt not installed)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(failed: clippy not installed)*
- `cargo test --all` *(failed)*

------
https://chatgpt.com/codex/tasks/task_e_683f54ebb86483328428ad5c4390043c